### PR TITLE
Memory Aware Code Snippet Views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const App: React.FC = () => {
         <Route path="/roles" exact component={Roles} />
         <Route path="/constitution" exact component={Constitution} />
         <Route path="/thanks" exact component={Thanks} />
-        <Route path="/lab" exact component={Lab}/>
+        <Route path="/lab" exact component={Lab} />
         <Route path="/code" exact component={Code} />
         <Route path="/code/new" exact component={NewCodeBlock} />
         <Route path="/code/:hash" exact component={CodeDetailView} />

--- a/src/components/pages/Code/CodeDetailView.tsx
+++ b/src/components/pages/Code/CodeDetailView.tsx
@@ -20,8 +20,16 @@ async function fetchCodeSnippets(_: string, hash?: string): Promise<CodeData> {
   return response[0];
 }
 
-function CodeDetailView(): JSX.Element {
-  const { hash } = useParams();
+type QueriedProps = {
+  readonly hash: string;
+};
+
+/**
+ * Rendered when on previously passed state data exists
+ * such as a new tab or direct to url load.
+ */
+function CodeDetailViewQueried(props: QueriedProps): JSX.Element {
+  const { hash } = props;
   const { status, data, error } = useQuery(
     ["fetching-single-snippet", hash],
     fetchCodeSnippets
@@ -68,6 +76,64 @@ function CodeDetailView(): JSX.Element {
     );
   }
   return <Container type="normal">No Results</Container>;
+}
+
+type PassedProps = {
+  readonly data: CodeData;
+};
+/** Rendered when state data exists and is passed on as to avoid refetching already
+ * fetched data.
+ */
+function CodeDetailViewPassed(props: PassedProps): JSX.Element {
+  const { content, hash, name, language } = props.data;
+
+  if (content.length === 1) {
+    return (
+      <Container type="normal">
+        <div className={css(styles.container)}>
+          <h5>
+            {name} - {hash}
+          </h5>
+          <AkCodeBlock
+            language={language.toString()}
+            text={content[0].toString()}
+          />
+        </div>
+      </Container>
+    );
+  } else if (content.length > 1) {
+    return (
+      <Container type="normal">
+        <div className={css(styles.container)}>
+          <h5>
+            {name} - {hash}
+          </h5>
+          <div className={css(styles.contentRow)}>
+            {content.map((x) => (
+              <div className={css(styles.blockHolder)}>
+                <AkCodeBlock
+                  language={language.toString()}
+                  text={x.toString()}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </Container>
+    );
+  }
+  return <Container type="normal">No Results</Container>;
+}
+
+function CodeDetailView(props: any): JSX.Element {
+  const { hash } = useParams();
+  const stateObject: CodeData = props.location.state;
+
+  if (stateObject) {
+    return <CodeDetailViewPassed data={stateObject} />;
+  }
+
+  return <CodeDetailViewQueried hash={hash} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/components/ui/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock.tsx
@@ -21,7 +21,18 @@ function CodeBlock({
   if (content.length === 1 && href) {
     return (
       <div className={css(styles.container)}>
-        <Link to={href} target="__blank">
+        <Link
+          to={{
+            pathname: href.toString(),
+            state: {
+              content,
+              hash,
+              name,
+              language,
+              href,
+            },
+          }}
+        >
           <h5>
             {name} - {hash}
           </h5>
@@ -32,14 +43,25 @@ function CodeBlock({
   } else if (content.length > 1 && href) {
     return (
       <div className={css(styles.container)}>
-        <Link to={href} target="__blank">
+        <Link
+          to={{
+            pathname: href.toString(),
+            state: {
+              content,
+              hash,
+              name,
+              language,
+              href,
+            },
+          }}
+        >
           <h5>
             {name} - {hash}
           </h5>
         </Link>
         <div className={css(styles.contentRow)}>
-          {content.map((x) => (
-            <div className={css(styles.blockHolder)}>
+          {content.map((x, i) => (
+            <div key={i.toString()} className={css(styles.blockHolder)}>
               <AkCodeBlock language={language.toString()} text={x.toString()} />
             </div>
           ))}


### PR DESCRIPTION
Passing previously fetched state to Detailed Code Snippets View to avoid redundant networking cost. Also covered cases with no passed in state context so if a component doesn't have state passed in from a previous networking request... like say hitting a /code/:hash directly from a url instead of a link on the code page or opening one in a new tab it fetches data over the network.